### PR TITLE
feat: syntax compatibility

### DIFF
--- a/ui/TranslationStatus.vue
+++ b/ui/TranslationStatus.vue
@@ -15,34 +15,32 @@ const defaultI18nLabels: {
 </script>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, type PropType } from 'vue'
 import { useData } from 'vitepress'
 
-const {
-  i18nLabels,
-  status
-} = withDefaults(
-  defineProps<{
-    i18nLabels: { [lang: string]: string }
-    status: Status
-  }>(),
-  {
-    i18nLabels: () => defaultI18nLabels,
-    status: () => ({})
-  }
-)
+const props = defineProps({
+    i18nLabels: {
+      type: Object as PropType<{ [lang: string]: string }>,
+      default: () => defaultI18nLabels
+    },
+    status: {
+      type: Object as PropType<Status>,
+      default: () => ({})
+    }
+  })
+
 
 const { site } = useData()
 const label = computed<string>(() => {
   const localeIndex = site.value.localeIndex
-  if (!localeIndex || localeIndex === originalLang || !status[localeIndex]) {
+  if (!localeIndex || localeIndex === originalLang || !props.status[localeIndex]) {
     return ''
   }
-  const { date, hash } = status[localeIndex]
+  const { date, hash } = props.status[localeIndex]
   return (
-    i18nLabels[localeIndex] ||
+    props.i18nLabels[localeIndex] ||
     defaultI18nLabels[localeIndex] ||
-    i18nLabels.en ||
+    props.i18nLabels.en ||
     defaultI18nLabels.en
   ).
     replace('${date}', `<time>${date}</time>`).

--- a/ui/TranslationStatus.vue
+++ b/ui/TranslationStatus.vue
@@ -15,32 +15,33 @@ const defaultI18nLabels: {
 </script>
 
 <script setup lang="ts">
-import { computed, type PropType } from 'vue'
+import { computed } from 'vue'
 import { useData } from 'vitepress'
 
-const props = defineProps({
-    i18nLabels: {
-      type: Object as PropType<{ [lang: string]: string }>,
-      default: () => defaultI18nLabels
-    },
-    status: {
-      type: Object as PropType<Status>,
-      default: () => ({})
-    }
-  })
+const props = withDefaults(
+  defineProps<{
+    i18nLabels: { [lang: string]: string }
+    status: Status
+  }>(),
+  {
+    i18nLabels: () => defaultI18nLabels,
+    status: () => ({})
+  }
+)
 
+const { i18nLabels, status } = props
 
 const { site } = useData()
 const label = computed<string>(() => {
   const localeIndex = site.value.localeIndex
-  if (!localeIndex || localeIndex === originalLang || !props.status[localeIndex]) {
+  if (!localeIndex || localeIndex === originalLang || !status[localeIndex]) {
     return ''
   }
-  const { date, hash } = props.status[localeIndex]
+  const { date, hash } = status[localeIndex]
   return (
-    props.i18nLabels[localeIndex] ||
+    i18nLabels[localeIndex] ||
     defaultI18nLabels[localeIndex] ||
-    props.i18nLabels.en ||
+    i18nLabels.en ||
     defaultI18nLabels.en
   ).
     replace('${date}', `<time>${date}</time>`).


### PR DESCRIPTION
fix: #4

### Description

Vue 3.5+ supports [Reactive Props Destructure](https://vuejs.org/api/sfc-script-setup.html#default-props-values-when-using-type-declaration). 

Given that the `TranslationStatus` component is sourced directly and needs to be compatible with multiple Vue 3 versions, this PR ensures compatibility with both `Vue 3.0+` and `Vue 3.5+`.